### PR TITLE
Fix requiresMainQueueSetup warnings

### DIFF
--- a/ios/RNFrequency.m
+++ b/ios/RNFrequency.m
@@ -10,6 +10,11 @@
 @implementation RNFrequency
 RCT_EXPORT_MODULE(Frequency);
 
++ (BOOL)requiresMainQueueSetup
+{
+   return YES;
+}
+
 static UInt32 const TWO_CHANNELS = 2;
 
 - (instancetype)init

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "react-native-frequency",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Overview
This fixes some of the warnings we were getting about requiring main queue setup in our native modules, by explicitly setting whether our native modules can be loaded in the background.

## Prior art:
https://github.com/wix/react-native-navigation/pull/1983/files
https://github.com/facebook/react-native/commit/220034c4d4c8a52f424e05c291a62b63b74447f3
https://github.com/invertase/react-native-firebase/issues/491